### PR TITLE
Continue to overwrite the bill as long as it's Estimated

### DIFF
--- a/lib/dbr.js
+++ b/lib/dbr.js
@@ -61,19 +61,33 @@ DBR.prototype.findDBR = function (month) {
 // Month is a UTC moment object for midnight on the first of the month.
 // TODO: is there a way to consolidate the handler in then() with findDBR()'s?
 DBR.prototype.findStagedDBR = function (month) {
-  let self = this
-  return new Promise(function (resolve, reject) {
-    self.getStagedDBRs()
-        .then(function (dbrs) {
-          let match = _.find(dbrs, function (d) { return month.isSame(d.Month) })
-          if (match === undefined) {
-            return reject(new Error(`Unable to find the staged DBR for ${month.format('MMMM YYYY')}.`))
-          } else {
-            return resolve(match)
-          }
-        })
-  })
-}
+  let self = this;
+    return Promise.all([self.getDBRs(), self.getStagedDBRs()]).then(function (values) {
+    if (values.length !== 2) {
+      throw new Error('Unknown values:' + JSON.stringify(values));
+    }
+    let dbrs = values[0];
+    let stagedDBRs = values[1];
+    let match = _.find(stagedDBRs, function(d) {
+      if (!month.isSame(d.Month)) {
+        return false;
+      }
+      // ok we have the right key.
+      let originalDBR = _.find(dbrs, function(d2) {
+        return month.isSame(d2.Month);
+      });
+      if (typeof originalDBR === 'undefined') {
+        // found staged, but no original, which is weird - use the staged match.
+        return true;
+      }
+      return originalDBR.LastModified === d.LastModified;
+    });
+    if (match === undefined) {
+      throw new Error(`Unable to find the staged DBR for ${month.format('MMMM YYYY')}.`);
+    }
+    return match;
+  });
+};
 
 // Get the contents of a bucket. Returns a promise which resolves with an array
 // of bucket objects.

--- a/lib/redshift.js
+++ b/lib/redshift.js
@@ -98,12 +98,28 @@ Redshift.prototype.latestFullMonth = function () {
   })
 }
 
-// Determine whether a specific finalized month has already been imported.
+// Determine whether a specific finalized month has already been imported, and
+// represents a complete invoice.
 Redshift.prototype.hasMonth = function (month) {
+  // Currently we mark a bill as "finalized" when a new month's bill appears in
+  // S3, but AWS continues to update a bill after a month is over for several
+  // days. The correct way to check for a "finalized" bill is to see whether the
+  // invoice_id row has a number or is marked as "Estimated". As long as the
+  // bill is estimated, we want to overwrite it with new data.
+  //
+  // We can't do this earlier on because that would require peeking at the S3
+  // data, so overwrite the data in the line_items table as long as it's not
+  // a finalized bill.
+  //
+  // Finally, some rows appear in the spreadsheet for a given month as "totals"
+  // of the other rows. These rows do not have an invoice_id (it's empty) hence
+  // the check for '' below.
   let query = `
     SELECT COUNT(*)
     FROM ${this.schema}.${this.lineItemsTableName}
-    WHERE statement_month = '${month.format('YYYY-MM-01')}';`
+    WHERE statement_month = '${month.format('YYYY-MM-01')}'
+      AND invoice_id != 'Estimated' AND invoice_id != ''
+  ;`;
   return this.getScalar(query, 'count').then(function (count) {
     return (count > 0)
   })


### PR DESCRIPTION
Currently we mark a bill as "finalized" when a new month's bill
appears in S3, but AWS continues to update a bill after a month is
over for several days. The correct way to check for a "finalized" bill
is to see whether the invoice_id row has a number or is marked as
"Estimated". As long as the bill is estimated, we want to overwrite it
with new data.

We can't do this earlier on because that would require peeking at the
S3 data, so overwrite the data in the line_items table as long as it's
not a finalized bill.

Finally, some rows appear in the spreadsheet for a given month as
"totals" of the other rows. These rows do not have an invoice_id (it's
empty) hence the check for '' below.